### PR TITLE
fix: firefox error serialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@looker/chatty",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@looker/chatty",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A simple postMessage host / client channel manager.",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -173,15 +173,7 @@ export class ChattyClient {
                   this.sendMsg(ChattyClientMessages.Response, { eventName, payload: resolvedResults }, sequence)
                 })
                 .catch(error => {
-                  const { message, name, fileName, lineNumber, columnNumber } = error
-                  const serializableError = {
-                    message,
-                    name,
-                    fileName,
-                    lineNumber,
-                    columnNumber
-                  }
-                  this.sendMsg(ChattyClientMessages.ResponseError, { eventName, payload: serializableError }, sequence)
+                  this.sendMsg(ChattyClientMessages.ResponseError, { eventName, payload: error.toString() }, sequence)
                 })
             }
             break
@@ -203,7 +195,8 @@ export class ChattyClient {
                 if (receiver.timeoutId) {
                   clearTimeout(receiver.timeoutId)
                 }
-                receiver.reject(evt.data.data.payload)
+                receiver.reject(typeof evt.data.data.payload === 'string' ?
+                  new Error(evt.data.data.payload) : evt.data.data.payload)
               }
             }
             break

--- a/src/client.ts
+++ b/src/client.ts
@@ -173,7 +173,15 @@ export class ChattyClient {
                   this.sendMsg(ChattyClientMessages.Response, { eventName, payload: resolvedResults }, sequence)
                 })
                 .catch(error => {
-                  this.sendMsg(ChattyClientMessages.ResponseError, { eventName, payload: error }, sequence)
+                  const { message, name, fileName, lineNumber, columnNumber } = error
+                  const serializableError = {
+                    message,
+                    name,
+                    fileName,
+                    lineNumber,
+                    columnNumber
+                  }
+                  this.sendMsg(ChattyClientMessages.ResponseError, { eventName, payload: serializableError }, sequence)
                 })
             }
             break

--- a/src/host.ts
+++ b/src/host.ts
@@ -198,15 +198,7 @@ export class ChattyHost {
                     this.sendMsg(ChattyHostMessages.Response, { eventName, payload: resolvedResults }, sequence)
                   })
                   .catch(error => {
-                    const { message, name, fileName, lineNumber, columnNumber } = error
-                    const serializableError = {
-                      message,
-                      name,
-                      fileName,
-                      lineNumber,
-                      columnNumber
-                    }
-                    this.sendMsg(ChattyHostMessages.ResponseError, { eventName, payload: serializableError }, sequence)
+                    this.sendMsg(ChattyHostMessages.ResponseError, { eventName, payload: error.toString() }, sequence)
                   })
               }
               break
@@ -230,7 +222,8 @@ export class ChattyHost {
                   if (receiver.timeoutId) {
                     clearTimeout(receiver.timeoutId)
                   }
-                  receiver.reject(evt.data.data.payload)
+                  receiver.reject(typeof evt.data.data.payload === 'string' ?
+                    new Error(evt.data.data.payload) : evt.data.data.payload)
                 }
               }
               break

--- a/src/host.ts
+++ b/src/host.ts
@@ -198,7 +198,15 @@ export class ChattyHost {
                     this.sendMsg(ChattyHostMessages.Response, { eventName, payload: resolvedResults }, sequence)
                   })
                   .catch(error => {
-                    this.sendMsg(ChattyHostMessages.ResponseError, { eventName, payload: error }, sequence)
+                    const { message, name, fileName, lineNumber, columnNumber } = error
+                    const serializableError = {
+                      message,
+                      name,
+                      fileName,
+                      lineNumber,
+                      columnNumber
+                    }
+                    this.sendMsg(ChattyHostMessages.ResponseError, { eventName, payload: serializableError }, sequence)
                   })
               }
               break

--- a/tests/chatty_client.spec.ts
+++ b/tests/chatty_client.spec.ts
@@ -373,7 +373,7 @@ describe('ChattyClient', function () {
               if (event.data === 'ClientBreakDown') {
                 expect(client.sendMsg).toHaveBeenCalledWith(
                   ChattyClientMessages.ResponseError,
-                  { eventName: 'bash', payload: { message: 'Break Down', name: 'Error', fileName: undefined, lineNumber: undefined, columnNumber: undefined } },
+                  { eventName: 'bash', payload: 'Error: Break Down' },
                   1)
                 done()
               }

--- a/tests/chatty_client.spec.ts
+++ b/tests/chatty_client.spec.ts
@@ -40,6 +40,7 @@ describe('ChattyClient', function () {
     return new Promise((_resolve, reject) => {
       setTimeout(() => {
         reject (new Error('Break Down'))
+        window.postMessage('ClientBreakDown', "*")
       })
     })
   }
@@ -368,13 +369,15 @@ describe('ChattyClient', function () {
               }
             })
 
-            setTimeout(() => {
-              expect(client.sendMsg).toHaveBeenCalledWith(
-                ChattyClientMessages.ResponseError,
-                { eventName: 'bash', payload: { message: 'Break Down', name: 'Error', fileName: undefined, lineNumber: undefined, columnNumber: undefined } },
-                1)
-              done()
-            }, 100) // ugly timeout - need to wait for breakDanceAsync to resolve
+            window.addEventListener('message', (event) => {
+              if (event.data === 'ClientBreakDown') {
+                expect(client.sendMsg).toHaveBeenCalledWith(
+                  ChattyClientMessages.ResponseError,
+                  { eventName: 'bash', payload: { message: 'Break Down', name: 'Error', fileName: undefined, lineNumber: undefined, columnNumber: undefined } },
+                  1)
+                done()
+              }
+            }, false)
           }).catch(console.error)
         })
 

--- a/tests/chatty_host.spec.ts
+++ b/tests/chatty_host.spec.ts
@@ -52,6 +52,7 @@ describe('ChattyHost', () => {
     return new Promise((_resolve, reject) => {
       setTimeout(() => {
         reject (new Error('Break Down'))
+        window.postMessage('HostBreakDown', "*")
       })
     })
   }
@@ -491,13 +492,15 @@ describe('ChattyHost', () => {
               }
             })
 
-            setTimeout(() => {
-              expect(host.sendMsg).toHaveBeenCalledWith(
-                ChattyHostMessages.ResponseError,
-                { eventName: 'bash', payload: { message: 'Break Down', name: 'Error', fileName: undefined, lineNumber: undefined, columnNumber: undefined } },
-                1)
-              done()
-            }, 100) // ugly timeout - need to wait for breakDanceAsync to resolve
+            window.addEventListener('message', (event) => {
+              if (event.data === 'HostBreakDown') {
+                expect(host.sendMsg).toHaveBeenCalledWith(
+                  ChattyHostMessages.ResponseError,
+                  { eventName: 'bash', payload: { message: 'Break Down', name: 'Error', fileName: undefined, lineNumber: undefined, columnNumber: undefined } },
+                  1)
+                  done()
+              }
+            }, false)
           }).catch(console.error)
         })
 

--- a/tests/chatty_host.spec.ts
+++ b/tests/chatty_host.spec.ts
@@ -496,7 +496,7 @@ describe('ChattyHost', () => {
               if (event.data === 'HostBreakDown') {
                 expect(host.sendMsg).toHaveBeenCalledWith(
                   ChattyHostMessages.ResponseError,
-                  { eventName: 'bash', payload: { message: 'Break Down', name: 'Error', fileName: undefined, lineNumber: undefined, columnNumber: undefined } },
+                  { eventName: 'bash', payload: 'Error: Break Down' },
                   1)
                   done()
               }


### PR DESCRIPTION
Firefox does not allow Error objects to be serialized over MessageChannel. This change converts Error object to plain old object when returning Errors from MessageWithResponse.